### PR TITLE
pkg-config 0.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,20 @@
 {
   "name": "pkg-config",
-  "version": "0.29.0",
+  "version": "0.29.2",
   "description": "pkg-config is a helper tool used when compiling applications and libraries.",
-  "source": "https://pkg-config.freedesktop.org/releases/pkg-config-0.29.tar.gz#f4b19d203b3896a4293af4b62c7f908063c88a5a",
+  "source": "https://pkg-config.freedesktop.org/releases/pkg-config-0.29.2.tar.gz#76e501663b29cb7580245720edfb6106164fad2b",
   "override": {
     "buildsInSource": true,
     "build": [
-      "./configure --prefix #{self.install}",
+      "find ./ -exec touch -t 200905010101 {} +",
+      "./configure --prefix #{self.install} --with-internal-glib",
       "make"
     ],
     "install": [
       "make install"
-    ]
+    ],
+    "buildEnv": {
+      "LDFLAGS": "#{os == 'darwin' ? '-framework CoreFoundation -framework Carbon' : ''} $LDFLAGS"
+    }
   }
 }


### PR DESCRIPTION
Upgrade to 0.29.2

On newer alpines, I was getting this error:

```
../../../git/glib/glib/gdate.c: In function 'g_date_strftime':
../../../git/glib/glib/gdate.c:2497:7: error: format not a string literal, format string not checked [-Werror=format-nonliteral]
       tmplen = strftime (tmpbuf, tmpbufsize, locale_format, &tm);
       ^~~~~~
```