### PR TITLE
Update to latest version of pkg-config (0.29.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "pkg-config",
-  "version": "0.29.0",
+  "version": "0.29.2",
   "description": "pkg-config is a helper tool used when compiling applications and libraries.",
-  "source": "https://pkg-config.freedesktop.org/releases/pkg-config-0.29.tar.gz#f4b19d203b3896a4293af4b62c7f908063c88a5a",
+  "source": "https://pkg-config.freedesktop.org/releases/pkg-config-0.29.2.tar.gz#76e501663b29cb7580245720edfb6106164fad2b",
   "override": {
     "buildsInSource": true,
     "build": [


### PR DESCRIPTION
On Ubuntu I kept hitting the following error:

```
    checking if internal glib should be used... no
    checking for pkg-config... /usr/bin/pkg-config
    checking pkg-config is at least version 0.9.0... yes
    checking for GLIB... no
    configure: error: Either a previously installed pkg-config or "glib-2.0 >= 2.16" could not be found. Please set GLIB_CFLAGS and GLIB_LIBS to the correct values or pass --with-internal-glib to configure to use the bundled copy.
```
Using the latest pkg-config seems to have fixed the issue, and I guess there's no point in staying at a previous version anyway! :smile: 